### PR TITLE
Fixed: Warning When Using Defmodel

### DIFF
--- a/docs/NN.scr
+++ b/docs/NN.scr
@@ -65,11 +65,65 @@ Applies a linear transformation to the incoming data: @c((setq y (!add (!matmul 
 @end(section)
 
 @begin(section)
-@title(Denselayer)
-@cl:with-package[name="cl-waffe.nn"](
-@cl:doc(struct DenseLayer)
-)
+@title(DenseLayer)
+Calling LinearLayer, and activation specified in @cl:param(activation).
+
+@begin(section)
+@title(Parameters)
+@begin[lang=lisp](code)
+(DenseLayer in-features out-features &optional (bias t) (activation :relu))
+@end[lang=lisp](code)
+@begin(deflist)
+
+@def(in-features (fixnum))
+@term(size of each input sample)
+
+@def(out-features (fixnum))
+@term(size of each output sample)
+
+@def(bias (boolean))
+@term(If set to nil, the layer will not learn an additive bias. default:t)
+
+@def(activation (keyword or function))
+@term(activation are following: :relu :sigmoid :tanh, If set to function, that is called as an activation.)
+
+@end(deflist)
 @end(section)
+
+@begin(section)
+@title(Shape)
+@begin(deflist)
+
+@def(Input)
+@term(x (Tensor) where the x is the shape of (batch-size in-features))
+@def(Output)
+@term(Output: an tensor that applied denselayer, where the tensor is the shape of (batch-size out-features))
+
+@end(deflist)
+@end(section)
+
+@begin(section)
+@title(Forward)
+@begin[lang=lisp](code)
+(call (DenseLayer 10 1) x)
+@end[lang=lisp](code)
+
+@begin(deflist)
+
+@def(x)
+@term(the input tensor)
+
+@end(deflist)
+@end(section)
+
+@begin(section)
+@title(Example)
+@begin[lang=lisp](code)
+(call (DenseLayer 10 1)  (!randn `(10 10)))
+@end[lang=lisp](code)
+@end(section)
+@end(section)
+
 
 @begin(section)
 @title(Dropout)

--- a/docs/NN.scr
+++ b/docs/NN.scr
@@ -11,9 +11,57 @@
 
 @begin(section)
 @title(Linearlayer)
-@cl:with-package[name="cl-waffe.nn"](
-@cl:doc(struct LinearLayer)
-)
+Applies a linear transformation to the incoming data: @c((setq y (!add (!matmul x weight) bias)))
+
+@begin(section)
+@title(Parameters)
+@begin[lang=lisp](code)
+(LinearLayer in-features out-features &optional (bias T))
+@end[lang=lisp](code)
+@begin(deflist)
+
+@def(in-features (fixnum))
+@term(size of each input sample)
+@def(out-features (fixnum))
+@term(size of each output sample)
+@def(bias (boolean))
+@term(If set to nil, the layer will not learn an additive bias. default:t)
+
+@end(deflist)
+@end(section)
+
+@begin(section)
+@title(Shape)
+@begin(deflist)
+
+@def(Input)
+@term(x (Tensor) where the x is the shape of (batch-size in-features))
+@def(Output)
+@term(Output: an tensor that applied linearlayer, where the tensor is the shape of (batch-size out-features))
+
+@end(deflist)
+@end(section)
+
+@begin(section)
+@title(Forward)
+@begin[lang=lisp](code)
+(call (LinearLayer 10 1) x)
+@end[lang=lisp](code)
+
+@begin(deflist)
+
+@def(x)
+@term(the input tensor)
+
+@end(deflist)
+@end(section)
+
+@begin(section)
+@title(Example)
+@begin[lang=lisp](code)
+(call (LinearLayer 10 1) (!randn `(10 10)))
+@end[lang=lisp](code)
+@end(section)
 @end(section)
 
 @begin(section)

--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -87,7 +87,43 @@ Output: Tensor"
 	    (!softmax-function x :avoid-overflow (self avoid-overflow))))
 
 (defun !softmax (x &key (avoid-overflow t))
-  "Nothing here"
+  "Applying softmax to x. !softmax has three behaviours depending on the number of dimensions.
+
+The number of dims is...
+@begin(deflist)
+@def(1)
+@begin(term)
+Softmax is applied to dim=0
+@begin[lang=lisp](code)
+(setq a (!randn `(10)))
+(!softmax a)
+;#Const((0.910... 0.886... ~ 0.802... 0.616...) :mgl t :shape (10))
+@end[lang=lisp](code)
+@end(term)
+
+@def(2)
+@begin(term)
+Softmax is applied to dim=0
+@begin[lang=lisp](code)
+
+@end[lang=lisp](code)
+@end(term)
+
+@def(3)
+@begin(term)
+Softmax is applied to dim=0
+@begin[lang=lisp](code)
+
+@end[lang=lisp](code)
+@end(term)
+
+@def(4)
+@begin(term)
+Todo: currently, it returns error.
+@begin[lang=lisp](code)
+@end[lang=lisp](code)
+@end(term)
+@end(deflist)"
   (call (SoftMaxNode avoid-overflow) x))
 
 ; Todo :docstring

--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -127,15 +127,26 @@ Todo: currently, it returns error.
   (call (SoftMaxNode avoid-overflow) x))
 
 ; Todo :docstring
-(defmodel model-list (model-args)
+(defmodel model-list (model-list &key (return-model? nil))
   :document (with-usage "model-list"
 	      :overview "define model sequentially, (e.g. x = (sequence `((layer1) (layer2))), (call x 1 tensor) => layer1's output)"
 	      :args "model1 model2 ..."
 	      :forward "@cl:param(index) represents the index of models. @cl:param(args) is the arguments for index-th model."
 	      :step-args "index &rest args")
-  :parameters ((mlist model-args))
+  :parameters ((mlist model-list)
+	       (return-model? return-model?))
   :forward ((index &rest args)
-	    (apply #'call (nth (data index) (self mlist)) args)))
+	    (if (self return-model?)
+		(nth (data index) (self mlist))
+		(apply #'call (nth (data index) (self mlist)) args))))
+
+(defun mlist (&rest models)
+  (model-list models :return-model? t))
+
+(defun mth (index mlist)
+  (call mlist (typecase index
+		(waffetensor index)
+		(T (const index)))))
 
 (defnode ArefTensor (shape)
   :regard-as-node nil

--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -127,26 +127,27 @@ Todo: currently, it returns error.
   (call (SoftMaxNode avoid-overflow) x))
 
 ; Todo :docstring
-(defmodel model-list (model-list &key (return-model? nil))
+(defmodel model-list (model-list)
   :document (with-usage "model-list"
 	      :overview "define model sequentially, (e.g. x = (sequence `((layer1) (layer2))), (call x 1 tensor) => layer1's output)"
 	      :args "model1 model2 ..."
 	      :forward "@cl:param(index) represents the index of models. @cl:param(args) is the arguments for index-th model."
 	      :step-args "index &rest args")
-  :parameters ((mlist model-list)
-	       (return-model? return-model?))
+  :parameters ((mlist model-list))
   :forward ((index &rest args)
-	    (if (self return-model?)
-		(nth (data index) (self mlist))
-		(apply #'call (nth (data index) (self mlist)) args))))
+	    (error "model-list couldn't pass call correctly")))
 
 (defun mlist (&rest models)
-  (model-list models :return-model? t))
+  "define mlist"
+  (model-list models))
 
 (defun mth (index mlist)
-  (call mlist (typecase index
-		(waffetensor index)
-		(T (const index)))))
+  "Accessor for model-list"
+  (declare (type model-list mlist))
+  (nth (typecase index
+	 (waffetensor (data index))
+	 (T index))
+       (model-list-mlist mlist)))
 
 (defnode ArefTensor (shape)
   :regard-as-node nil

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -353,6 +353,7 @@ Example:
 			      body
 			      hide-from-tree
 			      optimize
+			      object-type
 			      &optional (is-node nil)
 			      &aux (thread (gensym))
 				   (is-top (gensym))
@@ -377,11 +378,13 @@ Example:
 	   ,(if hide-from-tree `(declare (type waffetensor ,@vars)) nil)
 	   ; Utils that can be used in :forward and :backward
 
-	   ,@(map 'list #'(lambda (variable)
-			    `(setq ,variable (typecase ,variable
-					       (waffetensor ,variable)
-					       (T (const ,variable)))))
-		  `,vars)
+	   (when (not (eql ,object-type :optimizer))
+	       ,@(map 'list #'(lambda (variable)
+				`(setq ,variable (typecase ,variable
+						   (waffetensor ,variable)
+						   (T (const ,variable)))))
+		      `,vars))
+	   
 	   (macrolet ((self (name) `(slot-value ,',self-heap ',name))
 		      (save-for-backward (name value)
 			`(let ((thread-info (waffetensor-thread-data ,value))
@@ -574,6 +577,7 @@ the object-type indicates the type of document format."
 	     ,(cdr forward)
 	     ,hide-from-tree
 	     ,optimize
+	     ,object-type
 	     ,(not regard-as-node))
 	 (define-node-method
 	     call-backward
@@ -582,6 +586,7 @@ the object-type indicates the type of document format."
 	     ,(cdr backward)
 	     ,hide-from-tree
 	     ,optimize
+	     ,object-type
 	     ,(not regard-as-node))))))
 
 (defun render-simple-model-structure (stream model) ; Todo: More Details

--- a/source/nn/losses.lisp
+++ b/source/nn/losses.lisp
@@ -27,11 +27,11 @@
     result))
 
 (defun mse (p y)
-  "MSE"
+  "MSE Loss"
   (!mean (!pow (!sub p y) 2) 1))
 
 (defun cross-entropy (x y &optional (delta 1e-7) (epsilon 0.0))
-  "CrossEntropy"
+  "CrossEntropy Loss"
   ; epsilon ... an parameter for label smoothing
   ; Regards Correct=1-epsilon, Incorrect=epsilon
   ; x...
@@ -65,7 +65,7 @@
 	       (list dx dx))))
 
 (defun softmax-cross-entropy (x y &key (avoid-overflow t) (delta 1e-7) (epsilon 0.0))
-  "Softmax-Cross-Entropy"
+  "Softmax-Cross-Entropy Loss"
   (if (> (!dims x) (!dims y))
       (call
        (SoftMaxCrossEntropy :avoid-overflow avoid-overflow :delta delta)

--- a/source/nn/nlp.lisp
+++ b/source/nn/nlp.lisp
@@ -65,11 +65,14 @@
 	       (biredical biredical)
 	       (wo (linearlayer hidden-size hidden-size)))
 
-  :forward ((x &optional (hs (const NIL)))
+  :forward ((x &optional (hs nil))
 	    "Input: X = (BatchSize SentenceLength Embedding_Dim)
              Output (values x{t+1} h{t+1})"
 
-	    (let* ((batch-size (!shape x 0))
+	    (let* ((hs (if (null hs)
+			   (const NIL)
+			   hs))
+		   (batch-size (!shape x 0))
 		   (s-len (!shape x 1))
 		   (hs (if (null (data hs))
 			 (!zeros `(,batch-size

--- a/source/nn/utils.lisp
+++ b/source/nn/utils.lisp
@@ -1,7 +1,6 @@
 
 (in-package :cl-waffe.nn)
 
-
 ; An implementation of Inverted Dropout.
 (defnode Dropout (&optional (dropout-rate 0.5))
   :document (with-usage "Dropout"
@@ -11,9 +10,7 @@
 		(if (and (> dropout-rate 0.0)
 			 (< dropout-rate 1.0))
 		    dropout-rate
-		    (error "cl-waffe.nn: Dropout(x), x must be in the range of 0.0<x<1.0 where x is a single-float."))
-		:type
-		single-float)
+		    (error "cl-waffe.nn: Dropout(x), x must be in the range of 0.0<x<1.0 where x is a single-float.")))
 	       (mask T))
   :forward ((x)
 	    (if (eql (self mask) T) ; is first call?

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -698,7 +698,7 @@ Example:
 ;                 ...
 ;        (0.063... 0.607... ~ 0.460... 0.730...)) :mgl t :shape (10 10))
 @end[lang=lisp](code)"
-  (const (uniform-random! (make-mat dims))))
+  (!normal dims 0 1))
 
 (defun !beta (dims alpha beta)
   "Initializes tensor with samples of beta distribution in a faster way.

--- a/t/network.lisp
+++ b/t/network.lisp
@@ -3,6 +3,7 @@
 
 (in-suite :test)
 
+
 (defparameter x (!randn `(10 100)))
 
 (defparameter linearlayer1 (linearlayer 100 10 t))
@@ -12,6 +13,15 @@
 (defparameter denselayer2 (denselayer 100 10 t :sigmoid))
 (defparameter denselayer3 (denselayer 100 10 t :tanh))
 (defparameter denselayer4 (denselayer 100 10 t #'!tanh))
+
+(defparameter dropout (dropout 0.5))
+
+(defparameter model-list (model-list (list (linearlayer 10 1)
+					   (linearlayer 10 1))))
+
+(defun test-model-list ()
+  (call model-list (const 0) (!randn `(10 10)))
+  t)
 
 (defun test-model (model x)
   (let ((out (call model x)))
@@ -24,5 +34,8 @@
       (is (test-model denselayer1 x))
       (is (test-model denselayer2 x))
       (is (test-model denselayer3 x))
-      (is (test-model denselayer4 x)))
- 
+      (is (test-model denselayer4 x))
+      (is (test-model dropout x))
+      (is (test-model-list))
+      )
+


### PR DESCRIPTION
Fixed:
・Symbols like &key, &rest weren't available in the forward/backward slot but it's fixed.
・Solved warnings when using defmodel
・added: model-list/mlist/mth