### PR TITLE
Fixed: errors during training will cause problems.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -207,6 +207,125 @@ See also: [Document](https://hikettei.github.io/cl-waffe-docs/docs/using-tensor.
 ;#Const((0.01 0.01 ~ 0.01 0.01) :mgl t :shape (10))
 ```
 
+## Useful Lazy-Evaluation System
+
+`!transpose` will produce lazy-evaluated tensor, while `!transpose1` will do not.
+
+```lisp
+(setq a (!randn `(10 3)))
+;#Const(((0.411... 0.244... 2.828...)        
+;                 ...
+;        (-1.26... -1.41... 0.821...)) :mgl t :shape (10 3))
+(!transpose a)
+;#Const(#<FUNCTION (LABELS CL-WAFFE.BACKENDS.MGL::LAZYTRANSPOSE :IN CL-WAFFE.BACKENDS.MGL::LAZY-EVAL-TRANSPOSE) {100CA0F5EB}>)
+
+(!add * 1)
+;#Const(((1.411... 0.862... ~ 1.590... -0.26...)        
+;                 ...
+;        (3.828... 0.582... ~ -0.57... 1.821...)) :mgl t :shape (3 10))
+
+; It is much faster.
+(time (!matmul a (!transpose a)))
+;Evaluation took:
+;  0.000 seconds of real time
+;  0.000107 seconds of total run time (0.000101 user, 0.000006 system)
+;  100.00% CPU
+;  147,434 processor cycles
+;  0 bytes consed
+  
+;#Const(((8.227... -1.29... ~ -4.10... 1.458...)        
+;                 ...
+;        (1.458... 0.180... ~ -2.59... 4.273...)) :mgl t :shape (10 10))
+
+; Compared to !transpose1...
+(time (!matmul a (!transpose1 a)))
+;Evaluation took:
+;  0.178 seconds of real time
+;  0.176052 seconds of total run time (0.120406 user, 0.055646 system)
+;  98.88% CPU
+;  4 forms interpreted
+;  773 lambdas converted
+;  410,887,630 processor cycles
+;  25,051,200 bytes consed
+  
+;#Const(((8.227... -1.29... ~ -4.10... 1.458...)        
+;                 ...
+;        (1.458... 0.180... ~ -2.59... 4.273...)) :mgl t :shape (10 10))
+```
+
+```lisp
+(setq a (!randn `(10 10)))
+;#Const(((0.570... -0.13... ~ 0.217... 0.862...)        
+;                 ...
+;        (-0.12... 0.384... ~ -0.25... -0.91...)) :mgl t :shape (10 10))
+
+(setq lazy-evaluated-a (!transpose a))
+;#Const(#<FUNCTION (LABELS CL-WAFFE.BACKENDS.MGL::LAZYTRANSPOSE :IN CL-WAFFE.BACKENDS.MGL::LAZY-EVAL-TRANSPOSE) {100E48135B}>)
+
+(print lazy-evaluated-a)
+;#Const(#<FUNCTION (LABELS CL-WAFFE.BACKENDS.MGL::LAZYTRANSPOSE :IN CL-WAFFE.BACKENDS.MGL::LAZY-EVAL-TRANSPOSE) {100E48135B}>)
+(value lazy-evaluated-a)
+
+(print lazy-evaluated-a)
+;#Const(((0.570... 1.228... ~ 0.050... -0.12...)        
+;                 ...
+;        (0.862... -0.82... ~ 1.360... -0.91...)) :mgl t :shape (10 10))
+```
+
+## Tracing JIT
+
+This is stil experimental but...
+
+In `(with-jit)` macro, cl-waffe dynamically defines the kernel functions with lazy-evaluation system.
+
+```lisp
+
+; In default...
+
+(time (!log (!exp a)))
+;Evaluation took:
+;  0.000 seconds of real time
+;  0.000171 seconds of total run time (0.000130 user, 0.000041 system)
+;  100.00% CPU
+;  248,100 processor cycles
+;  3,232 bytes consed
+  
+;#Const(((0.570... -0.13... ~ 0.217... 0.862...)        
+;                 ...
+;        (-0.12... 0.384... ~ -0.25... -0.91...)) :mgl t :shape (10 10))
+
+(defun trace-operate ()
+  (with-jit
+     (time (const (value (!log (!exp a)))))))
+
+; The first call of trace-operate, it seems slow because cl-waffe traces and compiles code.
+(trace-operate)
+;Evaluation took:
+;  0.000 seconds of real time
+;  0.000183 seconds of total run time (0.000122 user, 0.000061 system)
+;  100.00% CPU
+;  240,442 processor cycles
+;  32,512 bytes consed
+  
+;#Const(((0.570... -0.13... ~ 0.217... 0.862...)        
+;                 ...
+;        (-0.12... 0.384... ~ -0.25... -0.91...)) :mgl t :shape (10 10))
+
+; However, after the second one, it will be faster.
+(trace-operate)
+;Evaluation took:
+;  0.000 seconds of real time
+;  0.000096 seconds of total run time (0.000087 user, 0.000009 system)
+;  100.00% CPU
+;  187,848 processor cycles
+;  0 bytes consed
+  
+;#Const(((0.570... -0.13... ~ 0.217... 0.862...)        
+;                 ...
+;        (-0.12... 0.384... ~ -0.25... -0.91...)) :mgl t :shape (10 10))
+```
+
+
 ## Extensible APIs
 
 See also: [Document](https://hikettei.github.io/cl-waffe-docs/docs/extend-library.html)

--- a/Readme.md
+++ b/Readme.md
@@ -216,15 +216,17 @@ See also: [Document](https://hikettei.github.io/cl-waffe-docs/docs/using-tensor.
 ;#Const(((0.411... 0.244... 2.828...)        
 ;                 ...
 ;        (-1.26... -1.41... 0.821...)) :mgl t :shape (10 3))
+
 (!transpose a)
 ;#Const(#<FUNCTION (LABELS CL-WAFFE.BACKENDS.MGL::LAZYTRANSPOSE :IN CL-WAFFE.BACKENDS.MGL::LAZY-EVAL-TRANSPOSE) {100CA0F5EB}>)
 
+; Generally, using delayed evaluation does not require additional new code.
 (!add * 1)
 ;#Const(((1.411... 0.862... ~ 1.590... -0.26...)        
 ;                 ...
 ;        (3.828... 0.582... ~ -0.57... 1.821...)) :mgl t :shape (3 10))
 
-; It is much faster.
+; Using !transpose is much faster for !matmul (even when the tensors are 3d/4d...).
 (time (!matmul a (!transpose a)))
 ;Evaluation took:
 ;  0.000 seconds of real time
@@ -264,6 +266,8 @@ See also: [Document](https://hikettei.github.io/cl-waffe-docs/docs/using-tensor.
 
 (print lazy-evaluated-a)
 ;#Const(#<FUNCTION (LABELS CL-WAFFE.BACKENDS.MGL::LAZYTRANSPOSE :IN CL-WAFFE.BACKENDS.MGL::LAZY-EVAL-TRANSPOSE) {100E48135B}>)
+
+; value will accept and evaluated lazy-evaluated tensor.
 (value lazy-evaluated-a)
 
 (print lazy-evaluated-a)

--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,13 @@ See also: [Document](https://hikettei.github.io/cl-waffe-docs/docs/mnist-tutoria
 # Features
 
 As of this writing:
+- Broadcasting
+- Destructive APIs
+- Rich APIs
+- Auto BackPropagations
+- Useful Lazy-Evaluation System
+- Tracing JIT
+- Extensible APIs
 
 ## Broadcasting Matrix.
 
@@ -278,7 +285,7 @@ See also: [Document](https://hikettei.github.io/cl-waffe-docs/docs/using-tensor.
 
 ## Tracing JIT
 
-This is stil experimental but...
+This is still experimental but...
 
 In `(with-jit)` macro, cl-waffe dynamically defines the kernel functions with lazy-evaluation system.
 

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -10,7 +10,7 @@ Utils for defnode/defmodel/defoptimizer
 (defgeneric call-forward  (self))
 (defgeneric call-backward (self))
 
-(defmacro with-no-grad (&body body &aux (no-grad-first (gensym)))
+(defmacro with-no-grad (&body body)
   "This macro is used in order to implict that codes below is ignored:
 save-for-backward, creating new node object, using backward and processes for it.
 
@@ -20,16 +20,12 @@ For tasks in which grads are not required, using it helps better performance.
 (with-no-grad
   (call (model) x))
 @end[lang=lisp](code)"
-  `(let ((,no-grad-first *no-grad*))
-     (setq *no-grad* t)
-     (prog1 (progn ,@body)
-       (setq *no-grad* ,no-grad-first))))
+  `(let ((*no-grad* t))
+     ,@body))
 
-(defmacro with-node-method-mode (&body body &aux (state-first (gensym)))
-  `(let ((,state-first *in-node-method*))
-     (setq *in-node-method* t)
-     (prog1 (progn ,@body)
-       (setq *in-node-method* ,state-first))))
+(defmacro with-node-method-mode (&body body)
+  `(let ((*in-node-method* t))
+     ,@body))
 
 (defmacro with-calling-layers (input &rest layers)
   "This macro allows to sequentially call layers.


### PR DESCRIPTION
Changed:
・with-no-grad/in-node-method macros are using dynamic scoping while it was used to not.
↑This was why errors during training will stop produce grads
・updated readme
↑Features about lazy-evaluation system, tracing jit.