### PR TITLE
Develop

### DIFF
--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -297,7 +297,6 @@ Todo: currently, it returns error.
 ; !aref, (setf !aref) function and nodes:
 
 (defnode ArefTensor (shape)
-;  :regard-as-node nil
   :parameters ((shape shape)
 	       (base-shape T))
   :forward ((x) (setf (self base-shape) (!shape x))
@@ -309,13 +308,11 @@ Todo: currently, it returns error.
 
 (defnode SetfArefTensor (shape)
   :parameters ((shape shape))
- ; :regard-as-node nil
   :forward ((x y)
 	    ; Note: defnode must produce new sysconst otherwise stackoverflow...
 	    (sysconst (data (apply #'!write-faref x y (self shape)))))
   :backward ((dy)
 	     (list dy (apply #'!faref dy (self shape)))))
-
 
 #|
 For those who are reading my ugly code.

--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -334,6 +334,7 @@ Note: !aref/(setf !aref) definitions are located at tensor.lisp
 
 ; wrapper
 (defun !write-faref (tensor value &rest dims)
+  "Overwrites to tensor, with reading value of dims."
   (unless (= (!dims value) (!dims tensor))
     (error "!write-faref: the size of dim doesn't match. use !unsqueeze and !squeeze to adjust it.: ~a and ~a" (!dims value) (!dims tensor)))
   ;(apply #'%write-faref tensor value dims)

--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -300,13 +300,9 @@ Todo: currently, it returns error.
   :regard-as-node nil
   :parameters ((shape shape)
 	       (base-shape T))
-
   :forward ((x) (setf (self base-shape) (!shape x))
 		(apply #'!faref x (self shape))) ;thread-node??
-  :backward ((dy)
-	     (let ((dy-n (!zeros (self base-shape))))
-	       (setf (!areflist dy-n (self shape)) dy)
-	       (list dy-n))))
+  :backward ((dy) (list dy)))
 
 (defnode SetfArefTensor (shape)
   :parameters ((shape shape))

--- a/source/functions.lisp
+++ b/source/functions.lisp
@@ -297,16 +297,19 @@ Todo: currently, it returns error.
 ; !aref, (setf !aref) function and nodes:
 
 (defnode ArefTensor (shape)
-  :regard-as-node nil
+;  :regard-as-node nil
   :parameters ((shape shape)
 	       (base-shape T))
   :forward ((x) (setf (self base-shape) (!shape x))
 		(apply #'!faref x (self shape))) ;thread-node??
-  :backward ((dy) (list dy)))
+    :backward ((dy)
+	     (let ((dy-n (!zeros (self base-shape))))
+	       (setf (!areflist dy-n (self shape)) dy)
+	       (list dy-n))))
 
 (defnode SetfArefTensor (shape)
   :parameters ((shape shape))
-  :regard-as-node nil
+ ; :regard-as-node nil
   :forward ((x y)
 	    ; Note: defnode must produce new sysconst otherwise stackoverflow...
 	    (sysconst (data (apply #'!write-faref x y (self shape)))))

--- a/source/kernel.lisp
+++ b/source/kernel.lisp
@@ -28,15 +28,18 @@ Here's:
        result)))
 
 (defmacro with-jit (&body body)
+  "In the codes below, tracing jit is enabled."
   `(let ((cl-waffe.backends.mgl::*force-disable-jit* nil)
 	 (cl-waffe.backends.mgl:*force-lazy-eval* t)
 	 (cl-waffe.backends.mgl:*verbose* nil))
      ,@body))
 
 (defmacro with-jit-debug (&body body)
+  "In the codes below, tracing jit is enabled.
+Also, compiled codes will be displayed."
   `(let ((cl-waffe.backends.mgl::*force-disable-jit* nil)
 	 (cl-waffe.backends.mgl:*force-lazy-eval* t)
-	 (cl-waffe.backends.mgl:*verbose* t))
+	 (cl-waffe.backends.mgl::*verbose* t))
      ,@body))
 
 (declaim (ftype (function (waffetensor) waffetensor) warranty))

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -414,6 +414,7 @@ Example:
 		 ;     `,vars))
 	   
 	   (macrolet ((self (name) `(slot-value ,',self-heap ',name))
+		      (model () `,',self-heap)
 		      (save-for-backward (name value)
 			`(let ((thread-info (waffetensor-thread-data ,value))
 			       (smaller-value (detach ,value)))

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -608,7 +608,7 @@ the object-type indicates the type of document format."
 					  (render-simple-model-structure stream m)))
 		       (:constructor ,name (,@args &aux (model-ident (gensym "WAFFEOBJECT")) ,@(map 'list (lambda (x) `(,(car x) ,(second x))) parameters))))
 	     ,doc-output
-	     (model-ident ,(gensym "WAFFEOBJECT") :type symbol)
+	     (model-ident ,(gensym "W") :type symbol)
 	     (hide-from-tree ,hide-from-tree :type boolean)
 	     (forward t :type boolean)
 	     (backward ,(if backward t nil) :type boolean)
@@ -635,10 +635,12 @@ the object-type indicates the type of document format."
 	 nil))))
 
 (defun render-simple-model-structure (stream model) ; Todo: More Details
-  (format stream "[~a: ~a]" (if (slot-value model 'hide-from-tree)
-				"Node "
-				"Model")
-	  (type-of model)))
+  (format stream "[~a: ~a {~a}]"
+	  (if (slot-value model 'hide-from-tree)
+	      "Node "
+	      "Model")
+	  (type-of model)
+	  (slot-value model 'model-ident)))
 
 (defun print-model (model)
   (fresh-line)

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -589,6 +589,7 @@ the object-type indicates the type of document format."
 		     (equal (symbol-name x) "hide-from-tree")
 		     (equal (symbol-name x) "parameters")
 		     (equal (symbol-name x) "model-ident")
+		     (equal (symbol-name x) "object-type")
 		     (equal (symbol-name x) "self"))
 		 (error "cl-waffe.defobject: the name ~a is not allowed to use as a parameter" (symbol-name x))
 		 x)))
@@ -607,11 +608,12 @@ the object-type indicates the type of document format."
 		       (:print-function (lambda (m stream k)
 					  (declare (ignore k))
 					  (render-simple-model-structure stream m)))
-		       (:constructor ,name (,@args &aux (model-ident (gensym "WAFFEOBJECT")) ,@(map 'list (lambda (x) `(,(car x) ,(second x))) parameters))))
+		       (:constructor ,name (,@args &aux (model-ident (gensym "W")) ,@(map 'list (lambda (x) `(,(car x) ,(second x))) parameters))))
 	     ,doc-output
 	     (model-ident ,(gensym "W") :type symbol)
 	     (hide-from-tree ,hide-from-tree :type boolean)
 	     (forward t :type boolean)
+	     (object-type ,object-type :type keyword)
 	     (backward ,(if backward t nil) :type boolean)
 	     (parameters ',(map 'list (lambda (x) (assure-args (car x))) parameters))
 	     ,@(map 'list (lambda (x) `(,(assure-args (car x)) ,(second x) ,@(cddr x))) parameters))
@@ -636,12 +638,23 @@ the object-type indicates the type of document format."
 	 nil))))
 
 (defun render-simple-model-structure (stream model) ; Todo: More Details
-  (format stream "[~a: ~a {~a}]"
-	  (if (slot-value model 'hide-from-tree)
-	      "Node "
-	      "Model")
-	  (type-of model)
-	  (slot-value model 'model-ident)))
+  (case (slot-value model 'cl-waffe::object-type)
+    (:node
+     (format stream "<Node: ~a{~a}>"
+	     (type-of model)
+	     (slot-value model 'cl-waffe::model-ident)))
+    (:model
+     (format stream "[Model: ~a :ident {~a}]"
+	     (type-of model)
+	     (slot-value model 'cl-waffe::model-ident)))
+    (:optimizer
+     (format stream "<<Optimizer: ~a :ident {~a}>>"
+	     (type-of model)
+	     (slot-value model 'cl-waffe::model-ident)))
+    (T
+     (format stream "[OBJECT: ~a {~a}]"
+	     (type-of model)
+	     (slot-value model 'cl-waffe::model-ident)))))
 
 (defun print-model (model)
   (fresh-line)

--- a/source/operators.lisp
+++ b/source/operators.lisp
@@ -292,7 +292,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :sin x))
   :backward ((dy)
-	     (list (!mul dy (!cos (self x))))))
+	     (list (!mul dy (!cos (self xi))))))
 
 (defnode CosTensor ()
   :optimize t
@@ -301,7 +301,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :cos x))
   :backward ((dy)
-	     (list (!mul dy (!mul -1.0 (!sin (self x)))))))
+	     (list (!mul dy (!mul -1.0 (!sin (self xi)))))))
 
 (defnode TanTensor ()
   :optimize t
@@ -310,7 +310,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :tan x))
   :backward ((dy)
-	     (list (!mul dy (!div 1 (!pow (!cos (self x)) 2))))))
+	     (list (!mul dy (!div 1 (!pow (!cos (self xi)) 2))))))
 
 (defnode ASinTensor ()
   :parameters ((xi nil))
@@ -318,7 +318,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :asin x))
   :backward ((dy)
-	     (list (!mul dy (!acos (self x))))))
+	     (list (!mul dy (!acos (self xi))))))
 
 (defnode ACosTensor ()
   :parameters ((xi nil))
@@ -326,7 +326,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :acos x))
   :backward ((dy)
-	     (list (!mul dy (!mul -1.0 (!asin (self x)))))))
+	     (list (!mul dy (!mul -1.0 (!asin (self xi)))))))
 
 (defnode ATanTensor ()
   :parameters ((xi nil))
@@ -334,7 +334,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :atan x))
   :backward ((dy)
-	     (list (!mul dy (!div 1 (!pow (!acos (self x)) 2))))))
+	     (list (!mul dy (!div 1 (!pow (!acos (self xi)) 2))))))
 
 (defnode ASinhTensor ()
   :parameters ((xi nil))
@@ -342,7 +342,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :asinh x))
   :backward ((dy)
-	     (list (!mul dy (!acosh (self x))))))
+	     (list (!mul dy (!acosh (self xi))))))
 
 (defnode ACoshTensor ()
   :parameters ((xi nil))
@@ -350,7 +350,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :acosh x))
   :backward ((dy)
-	     (list (!mul dy (!mul -1.0 (!asinh (self x)))))))
+	     (list (!mul dy (!mul -1.0 (!asinh (self xi)))))))
 
 (defnode ATanhTensor ()
   :parameters ((xi nil))
@@ -358,7 +358,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :atanh x))
   :backward ((dy)
-	     (list (!mul dy (!div 1 (!pow (!acosh (self x)) 2))))))
+	     (list (!mul dy (!div 1 (!pow (!acosh (self xi)) 2))))))
 
 (defnode HyperbolicSinTensor ()
   :optimize t
@@ -367,7 +367,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :sinh x))
   :backward ((dy)
-	     (list (!mul dy (!cosh (self x))))))
+	     (list (!mul dy (!cosh (self xi))))))
 
 (defnode HyperbolicCosTensor ()
   :optimize t
@@ -376,7 +376,7 @@ And utils for broadcasting etc...
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :cosh x))
   :backward ((dy)
-	     (list (!mul dy (!sinh (self x))))))
+	     (list (!mul dy (!sinh (self xi))))))
 
 (defnode AbsTensor ()
   :optimize t

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -6,42 +6,42 @@
   (:use :cl :mgl-mat :alexandria :inlined-generic-function)
   (:export #:*verbose*
 	   #:with-verbose)
+  (:export #:with-jit
+	   #:with-jit-debug)
   (:export #:*single-value*)
-  (:export
-           ; Functions and structures for tensor
-           #:waffetensor
-           #:tensor
+  (:export #:waffetensor
+	   #:tensor
 	   #:const
-	   #:sysconst
-	   
+	   #:sysconst)
+  (:export 
 	   ; An parameters for displaying tensor.
 	   #:*print-char-max-len*
 	   #:*print-arr-max-size*
-	   #:*print-mat-max-size*
+	   #:*print-mat-max-size*)
 
+  (:export
 	   #:!allow-destruct
-	   #:!disallow-destruct
+	   #:!disallow-destruct)
 
-	   ; Functions for using tensor's data
-	   #:warranty
+  (:export
+	   ; Accessors
+           #:warranty
+           #:waffe-tensor-p	   
 	   #:data
 	   #:value
-	   #:grad
-
-	   #:*in-node-method*
-
+	   #:grad)
+  (:export
 	   #:waffedatatype
-	   #:waffe-array
+	   #:waffe-array)
+  (:export
+   #:waffetensor-thread-data
+   #:waffetensor-is-next-destruct?)
 
-	   #:waffetensor-thread-data
-
+  (:export
 	   #:with-no-grad
-	   #:with-jit
-	   #:*no-grad*
+	   #:*no-grad*)
 
-	   #:waffe-tensor-p
-	   #:waffetensor-is-next-destruct?
-
+  (:export
 	   #:with-searching-calc-node
 	   #:defmodel
 	   #:defnode
@@ -51,6 +51,7 @@
 	   #:WaffeDataset
 
 	   #:save-for-backward
+
 	   #:reset-config
 	   
 	   #:step-model
@@ -59,44 +60,48 @@
 	   #:get-dataset-length
 
 	   #:call-and-dispatch-kernel
-	   #:with-optimized-operation
+	   #:with-optimized-operation)
 
-	   #:model
+  (:export ; macros in waffe-object
+           #:model
+	   #:self
 	   #:update
-	   #:zero-grad
+	   #:zero-grad)
 
+  (:export
+           #:mlist
+	   #:mth
 	   #:model-list
-	   #:with-model-list
+	   #:with-model-list)
 
-	   #:forward
-	   #:backward
-	   #:parameters
-	   #:hide-from-tree
-
+  (:export
 	   #:train
 	   #:get-dataset
-	   #:get-dataset-length
-	   
+	   #:get-dataset-length)
+
+  (:export 
 	   #:parameter
 	   #:call
-	   #:backward
+	   #:backward)
 
+  (:export
 	   #:!set-batch
-	   #:!reset-batch
+	   #:!reset-batch)
 
+  (:export
 	   #:waffetensor-destructively-calln
 	   #:waffetensor-destructive?
 	   #:waffetensor-is-data-destructed?
 	   #:waffetensor-report-index
 	   #:with-ignore-optimizer
-	   #:*ignore-optimizer*
+	   #:*ignore-optimizer*)
 
-	   #:self
-
+  (:export
 	   #:print-model
-
 	   #:*default-backend*
-	   #:extend-from
+	   #:extend-from)
+
+  (:export
 	   #:!zeros
 	   #:!ones
 	   #:!fill
@@ -126,8 +131,9 @@
 	   #:!full-like
 
 	   #:!filter
-	   #:with-calling-layers
+	   #:with-calling-layers)
 
+  (:export
 	   #:!add
 	   #:!!add
 	   #:!sub
@@ -135,8 +141,9 @@
 	   #:!mul
 	   #:!!mul
 	   #:!div
-	   #:!!div
+	   #:!!div)
 
+  (:export
 	   #:!dot
 	   #:!sum
 
@@ -151,8 +158,9 @@
 	   #:!exp
 	   #:!matmul
 	   #:!repeats
-	   #:!abs
+	   #:!abs)
 
+  (:export
 	   #:!sin
 	   #:!cos
 	   #:!tan
@@ -166,7 +174,9 @@
 	   #:!atanh
 
 	   #:!argmin
-	   #:!argmax
+	   #:!argmax)
+
+  (:export
 	   
 	   #:!squeeze
 	   #:!unsqueeze
@@ -180,19 +190,16 @@
 	   #:!leakey-relu
 	   #:!swish
 	   #:Swish
-	   #:!gelu
+	   #:!gelu)
 
+  (:export
 	   #:!concatenate
 	   #:!split
 	   #:!stack
 	   #:!vstack
 	   #:!hstack
 
-	   #:with-usage
-	   #:mlist
-	   #:mth
-
-	   ))
+	   #:with-usage))
 
 (defparameter *cl-waffe-object-types* `(:model
 					:node

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -4,6 +4,9 @@
 (defpackage cl-waffe
   (:documentation "An package for defining node, initializing and computing with tensor, and backprops.")
   (:use :cl :mgl-mat :alexandria :inlined-generic-function)
+  (:export #:*verbose*
+	   #:with-verbose)
+  (:export #:*single-value*)
   (:export
            ; Functions and structures for tensor
            #:waffetensor

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -12,7 +12,11 @@
   (:export #:waffetensor
 	   #:tensor
 	   #:const
-	   #:sysconst)
+	   #:sysconst
+	   #:parameters
+	   #:hide-from-tree
+	   #:forward
+	   #:backward)
   (:export 
 	   ; An parameters for displaying tensor.
 	   #:*print-char-max-len*

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -65,6 +65,7 @@
   (:export ; macros in waffe-object
            #:model
 	   #:self
+	   #:save-for-backward
 	   #:update
 	   #:zero-grad)
 
@@ -207,3 +208,59 @@
 					:optimizer
 					:dataset)
   "An identifiers of cl-waffe's objects.")
+
+(defmacro save-for-backward (slot tensor)
+  (error "Welcome to cl-waffe.
+Attempting your tensor ~a to a slot ~a, but save-for-backward wasn't called in:
+1. defmodel's forward or backward.
+2. defnode's forward or backward.
+
+save-for-backward is useful when registering temporary tensor depending on the case when copied tensor will be used when backwards.
+
+For example:
+
+(defnode XXX nil
+:forward ((x)
+          (!exp x) ; <- (!exp x) doesn't copies x
+..."
+	 slot
+	 tensor))
+
+(defmacro self (name)
+  (error "Welcome to cl-waffe.
+Attempting to access ~a but couldn't.
+This is because self wasn't called in:
+1. defmodel's forward or backward
+2. defnode's forward or backward
+3. defoptimizer's update
+4. defdataset's slots
+5. deftrainer's slots
+
+By using self, you can access cl-waffe's model parameter.
+For example:
+
+(defmodel XXX nil
+  :parameters ((A 0))
+  :forward ((x)
+            (+ (self A) x)))" name))
+
+(defmacro model ()
+  (error "Welcome to cl-waffe.
+Attempting to access the currently model but (model) wasn't called in:
+1. defmodel/defnode's forward or backward
+2. defoptimizer's slots"))
+
+(defmacro update (&rest args)
+  (declare (ignore args))
+  (error "Welcome to cl-waffe.
+The macro (update) can only be called in deftrainer's slots.
+For details, documentations are available.
+
+https://hikettei.github.io/cl-waffe-docs/docs/cl-waffe.html#3-deftrainer"))
+
+(defmacro zero-grad ()
+  (error "Welcome to cl-waffe.
+The macro (zero-grad) can only be called in deftrainer's slots.
+For details, documentations are available.
+
+https://hikettei.github.io/cl-waffe-docs/docs/cl-waffe.html#3-deftrainer"))

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -1467,8 +1467,10 @@ Return: A tensor of shape that equal to the condition.
     result)))
 
 (defun write-description (res backward backend)
+  (declare (ignore backward res backend))
   ; Parameter { ... <= here }
-  (write-string (format nil " :device :~a :backward ~A" backend backward) res))
+  ;(write-string (format nil " :device :~a" backend) res)
+  )
 
 (defun reduce-str (obj)
   ; align string content of tensor following *print-char-max-len*
@@ -1574,7 +1576,7 @@ Return: A tensor of shape that equal to the condition.
 							 (if (null grad)
 							     (+ indent-size (length "#Const("))
 							     (+ indent-size (length "#Parameter{"))))
-		(write-string (format nil " :mgl t :shape ~a" (mgl-mat:mat-dimensions contents)) res)
+		(write-string (format nil " :mgl t :shape ~a :backward ~a" (mgl-mat:mat-dimensions contents) (waffetensor-state tensor)) res)
 		(unless (null grad)
 		  (write-description res backward backend))
 		(if (null grad)

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -107,6 +107,7 @@ cl-waffe automatically coerce them to arbitary types
   (thread-idx 0 :type fixnum)
   (cache-n 0 :type fixnum))
 
+; To add: create tensors with (tensor a :debug t) which enables displaying more informations (e.g.: mat's memory-address)
 (defstruct (WaffeTensor (:print-function
 			 (lambda (tensor stream depth)
 			    (declare (ignore depth))

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -42,6 +42,11 @@ Default: 6")
 
 (defparameter *lazy-backwards* nil)
 
+(defmacro with-verbose (&body body)
+  "The codes below, the computation nodes will be displayed when backward"
+  `(let ((*verbose* t))
+     ,@body))
+
 (deftype WaffeSupportedDataType ()
   "An type of waffe-tensor's content type,
 

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -543,12 +543,9 @@ In the process calculating backward, new backwards won't be created. (*no-grad* 
 
 		   (when *verbose*
 		     (format t "Resumption from Lazy Evaluated==~%"))
-
-		   (dotimes (i (length (waffetensor-variables result-tmp)))
-		     (setf (waffetensor-thread-data result-tmp)
-			   (waffetensor-thread-data first-tensor))
-		     (setfgradtmp (nth-var result-tmp i) result-tmp)
-		     (step-next-node result-tmp i)))))
+		   
+		   (setfgradtmp result-tmp result-tmp)
+		   (backward1 result-tmp))))
 	(backward1 tensor)
 	(loop while (not (= 0 (hash-table-count *lazy-backwards*)))
 	      do (maphash #'backward-by-id *lazy-backwards*)))
@@ -621,7 +618,7 @@ backward1 does following in order to optimize:
 		   (higher-node-id (slot-value called-from-state 'model-ident)))
 	      (unless (= 1 (length variables))
 		(error "cl-waffe's internal error: the size of !aref's retent should be 1 but got: ~a" variables))
-		
+
 	      ; Pseudo, moves down one node.
 	      (setf (waffetensor-backward grad-before)
 		    (waffetensor-backward (car variables)))

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -14,8 +14,9 @@ Here's utils for tensor.
   "When t, some node will be ignored. see references below for details. default: nil")
 
 (defparameter *verbose* nil)
+(defparameter *single-node* nil "This parameter becames t when backward, the size of x.variables is 1.")
 (defparameter *backward-indents* 0)
-(declaim (type boolean *verbose*)
+(declaim (type boolean *verbose* *single-node*)
 	 (type fixnum *backward-indents*))
 
 (defparameter *print-char-max-len* 5
@@ -536,8 +537,11 @@ In the process calculating backward, new backwards won't be created. (*no-grad* 
 			      (sysconst 1.0))))
 	; calculating backward(state, dy) -> x.grad, y.grad...
 
-	(let ((*backward-indents* (if *verbose*
-				      (+ *backward-indents* 1)
+	(let ((*single-node* (= 1 (length (the list (waffetensor-variables tensor)))))
+	      (*backward-indents* (if *verbose*
+				      (if *single-node*
+					  (+ *backward-indents* 1)
+					  *backward-indents*)
 				      0)))
 	  (let ((grads (funcall
 			(the function

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -561,16 +561,14 @@ In the process calculating backward, new backwards won't be created. (*no-grad* 
 backward1 does following in order to optimize:
 
 1. Nodes like... (Any Node -> !aref) is registered to *lazy-backwards*.
-  Step1. backwardを呼び出して, !arefより上の階層の計算ノードの微分を終わらせる
+  Step1. backward1を呼び出して, !arefより上の階層の計算ノードの微分を終わらせる
   Step2. backward関数内で, *lazy-backwards* にある計算ノードがあったら、それをbackward1で!arefが出現するノードまでか末端まで計算.
 
   Step3. Step2で*lazy-backwards*がNILになるまで繰り返す。
 
-ほぼ!aref専用の最適化
-
-2. *single-value*がtの場合、計算ノードが分岐しないから(Tracing JITで解決しようと必死だったやつ) 破壊的に計算してOK
+2. *single-value*がtの場合、計算ノードが分岐しないから(Tracingで解決しようと必死だったやつ) 破壊的に計算してOK
 "
-  (declare (optimize (speed 3)); (safety 0))
+  (declare (optimize (speed 3) (safety 0))
 	   (type waffetensor tensor))
   
   ; Displaying Backward Nodes, when *verbose* is t.
@@ -611,11 +609,11 @@ backward1 does following in order to optimize:
 	      [Node: AddTensor {0}]
 	    Stops exploring deeper of addtensor until all areftensor will be registered.
 	    |#
-	    (let* ((variables (waffetensor-variables tensor))
+	    (let* ((grad-before (grad-tmp-value grad-tmp-before))
+		   (variables (waffetensor-variables tensor))
 		   (state (waffetensor-state tensor))
 		   (called-from-state (waffetensor-state (car variables)))
 		   (higher-node-id (slot-value called-from-state 'model-ident)))
-
 	      (unless (= 1 (length variables))
 		(error "cl-waffe's internal error: the size of !aref's retent should be 1 but got: ~a" variables))
 		

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -562,6 +562,8 @@ In the process calculating backward, new backwards won't be created. (*no-grad* 
   "
 backward1 does following in order to optimize:
 
+I'm sorry for writing in Japanese...
+
 1. Nodes like... (Any Node -> !aref) is registered to *lazy-backwards*.
   Step1. backward1を呼び出して, !arefより上の階層の計算ノードの微分を終わらせる
   Step2. backward関数内で, *lazy-backwards* にある計算ノードがあったら、それをbackward1で!arefが出現するノードまでか末端まで計算.

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -511,7 +511,7 @@ In the process calculating backward, new backwards won't be created. (*no-grad* 
   (if (typep (data tensor) 'mgl-mat:mat)
       (unless (eq (!shape tensor) `(1))
 	(error "grad can be implicitly created only for scalar outputs")))
-  (with-no-grad
+  (let ((*no-grad* t))
     (let ((*lazy-backwards* (make-hash-table)))
       (labels ((backward-by-id (id lazy-tensors)
 		 (remhash id *lazy-backwards*)
@@ -598,8 +598,12 @@ backward1 does following in order to optimize:
 				     0)))
 	 ; Each node has its own specific optimisation described below.
 	 (cond
-	   ((areftensor-p
-	     (waffetensor-state tensor))
+	   ((and
+	     (waffetensor-state
+	      (car
+	       (waffetensor-variables tensor)))
+	     (areftensor-p
+	      (waffetensor-state tensor)))
 	    #| Explain: When Node is Like...
 	    [Node: ArefTensor {A1}]
 	      [Node: AddTensor {0}]|

--- a/t/deriv.lisp
+++ b/t/deriv.lisp
@@ -6,3 +6,56 @@
 ; Tests for backward (its test integrated to optimizers)
 
 
+(defun aref-backward1 ()
+  (let* ((tensor (!randn `(10 10)))
+	 (a (parameter (const (mgl-mat:copy-mat (data tensor)))))
+	 (b (!aref a 0))
+	 (c (!sum b)))
+    (backward c)
+    (mgl-mat:M=
+     (data (!fill `(10) 0.1))
+     (data (!aref (const (grad a)) 0)))))
+
+(defun aref-backward2 ()
+  (let* ((tensor (!randn `(10 10)))
+	 (grad (!mul (!exp tensor) 0.1))
+	 (a (parameter tensor))
+	 (b (!exp a))
+	 (c (!aref b 0))
+	 (d (!sum c)))
+    (backward d)
+    (mgl-mat:M=
+     (data (!aref grad 0))
+     (data (!aref (const (grad a)) 0)))))
+
+(defun aref-backward3 ()
+  (let* ((tensor (!randn `(10 10)))
+	 (grad (!mul (!exp tensor) 0.1))
+	 (a (parameter tensor))
+	 (b (!exp a))
+	 (c (!aref b 0))
+	 (c (!aref c 0))
+	 (c (!aref c 0))
+	 (d (!sum c)))
+    (backward d)
+    (mgl-mat:M=
+     (data (!aref grad 0))
+     (data (!aref (const (grad a)) 0)))))
+
+(defun aref-backward4 ()
+  (let* ((tensor (!randn `(10 10)))
+	 (a (parameter tensor))
+	 (b (!add a 1.0))
+	 (c (!aref b 0))
+	 (d (!sum c)))
+    (backward d)
+    (mgl-mat:M=
+     (data (!fill `(10) 0.1))
+     (data (!aref (const (grad a)) 0)))))
+
+(test aref-backwards
+      (is (aref-backward1))
+      (is (aref-backward2))
+      (is (aref-backward3))
+      (is (aref-backward4)))
+      


### PR DESCRIPTION
1. Fixed: !aref's backward requires a lot of memory by using lazy-evaluation
2. added macros and binding then: (self) (save-for-backward) etc... returning errors.
3. More details when printing tensors
4. put together exports
5, added verbose option which displays computation nodes
6. fixed sin~atanh's backward