### PR TITLE
Inlined some functions

### DIFF
--- a/source/kernel.lisp
+++ b/source/kernel.lisp
@@ -100,7 +100,8 @@ Note: this is not setfable"
 
 ;(declaim (ftype (function (keyword cons) waffetensor) invoke-mgl-kernel invoke-cpu-kenel))
 (defun invoke-mgl-kernel (kernel-function variables &key (output nil) (overwrite nil))
-  (declare (optimize (speed 3)))
+  (declare (optimize (speed 3) (safety 0))
+	   (inline cl-waffe.backends.mgl:dispatch-kernel))
   (sysconst (cl-waffe.backends.mgl:dispatch-kernel
 				  kernel-function
 				  *destructive-operation*
@@ -121,7 +122,8 @@ Note: this is not setfable"
 					     variables))))
 
 (defun invoke-cpu-kernel (kernel-function variables)
-  (declare (optimize (speed 3)))
+  (declare (optimize (speed 3) (safety 0))
+	   (inline cl-waffe.backends.cpu:dispatch-kernel))
   (sysconst (cl-waffe.backends.cpu:dispatch-kernel kernel-function variables)
 	    :thread-data (let ((r (find t (the list variables)
 					:test (lambda (x y)
@@ -141,9 +143,11 @@ Note: this is not setfable"
 		      &key
 			(output nil)
 			(overwrite nil))
-  (declare (optimize (speed 3))
+  (declare (optimize (speed 3) (safety 0))
 	   (type boolean overwrite)
-	   (ignore first-argument i))
+	   (ignore first-argument i)
+	   (inline invoke-cpu-kernel
+		   invoke-mgl-kernel))
   (let ((has-mat (member-if #'(lambda (x)
 				(when (typep x 'waffetensor)
 				  (or (typep (data x) 'mgl-mat:mat)

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -15,12 +15,13 @@ Utils for defnode/defmodel/defoptimizer
   (:arguments node)
   (let ((extensions-call-form (mapcar
 			       #'(lambda (method)
-				   `(call-method ,method))
+				   `(the (or function null)
+					 (call-method ,method)))
 			       external-methods)))
     `(or ,@extensions-call-form
 	 ,(cond
 	    ((null external-methods)
-	     `(call-method ,(first mgl-node-method)))
+	     `(the function (call-method ,(first mgl-node-method))))
 	    ((eql *default-backend* :mgl)
 	     `(call-method ,(first mgl-node-method)))
 	    (T
@@ -159,6 +160,7 @@ Output: Waffetensor of list which comprised of waffetensor."
 	    (list
 	     (mapc
 	      #'(lambda (r)
+		  (declare (type waffetensor r))
 		  (setf (waffetensor-backward r) t)
 		  (setf (waffetensor-state r) model)
 		  (setf (waffetensor-variables r) args)
@@ -517,7 +519,8 @@ Example:
 		  (eql :mgl ,required-backend-symbol)
 		  (eql *default-backend* ,required-backend-symbol))
 	     #'(lambda (&rest node-inputs)
-		 (declare (inline apply ,f-ident))
+		 (declare (optimize (speed 3) (safety 0))
+			  (inline ,f-ident))
 		 (apply #',f-ident self node-inputs)))))))
 
 (defmacro defmodel (name args

--- a/source/operators.lisp
+++ b/source/operators.lisp
@@ -77,7 +77,7 @@ And utils for broadcasting etc...
 		 y))))))
 
 (defun same-shape-p (x y)
-  (declare (optimize (speed 3))
+  (declare (optimize (speed 3) (safety 0))
 	   (type waffetensor x y))
   (or
    (or (not (typep (data x) 'mat))
@@ -158,7 +158,7 @@ And utils for broadcasting etc...
   :optimize t
   :parameters ((xi T) (yi T))
   :forward ((x y)
-	    (unless (= (data x) 1) (error "!div-old: x must be 1"))
+	    (unless (= (the fixnum (data x)) 1) (error "!div-old: x must be 1"))
             (save-for-backward xi x)
 	    (save-for-backward yi y)
 	    (with-searching-calc-node :div x y))
@@ -170,7 +170,7 @@ And utils for broadcasting etc...
   (let ((place node-object))
     `(defun ,name ,args
        ,doc
-       (declare (optimize (speed 3) (safety 1)))
+       (declare (optimize (speed 3) (safety 1) (compilation-speed 0)))
        (let* ((,tensor (if *no-grad* ,place ,node-object)))
 	 ,@body))))
 

--- a/source/operators.lisp
+++ b/source/operators.lisp
@@ -7,6 +7,7 @@ And utils for broadcasting etc...
 |#
 
 (declaim (ftype (function (t) waffetensor) assure-tensor))
+(declaim (inline assure-tensor))
 (defun assure-tensor (x)
   "This function is used in order to implement this: e.g. (!add 1 1)"
   (typecase x


### PR DESCRIPTION
Inlining of functions and faster back-end allocation.

The first time is slow because define-method-combinations is called, but from the second time onwards, even via cl-waffe, it is approximately 20 times slower than calling the standard CommonLisp functions. (even though cl-waffe records compute nodes and determines kernel allocation.)

```lisp
CL-WAFFE> (time (!add 0.0 0.0))
Evaluation took:
  0.004 seconds of real time
  0.004930 seconds of total run time (0.001745 user, 0.003185 system)
  125.00% CPU
  8 lambdas converted
  11,357,142 processor cycles
  468,320 bytes consed
  
#Const(0.0)
CL-WAFFE> (time (!add 0.0 0.0))
Evaluation took:
  0.000 seconds of real time
  0.000011 seconds of total run time (0.000011 user, 0.000000 system)
  100.00% CPU
  24,550 processor cycles
  0 bytes consed
  
#Const(0.0)
CL-WAFFE> (time (+ 0.0 0.0))
Evaluation took:
  0.000 seconds of real time
  0.000001 seconds of total run time (0.000001 user, 0.000000 system)
  100.00% CPU
  334 processor cycles
  0 bytes consed
  
0.0
CL-WAFFE>
```