### PR TITLE
Enhancement: Declare forms in :forward/:backward

### DIFF
--- a/source/activations.lisp
+++ b/source/activations.lisp
@@ -9,9 +9,10 @@
 	       (zero-buff nil))
   :forward-declaim (declaim (ftype (function (ReLUTensor waffetensor) waffetensor) :forward))
   :forward ((x)
-	    (declare (optimize (speed 3)))
+	    (declare (optimize (speed 3) (safety 0)))
 	    (unless (self zero-buff)
 	      (setf (self zero-buff) (!zeros (!shape x))))
+
 	    (let ((mask (with-searching-calc-node :< x (self zero-buff))))
 	      (save-for-backward path-through mask)
 	      (!mul mask x)))
@@ -33,10 +34,18 @@ Output: Tensor"
 
 (defnode SigmoidTensor nil
   :parameters ((xi T))
+  :forward-declaim (declaim (ftype (function (SigmoidTensor waffetensor) waffetensor) :forward))
   :forward ((x)
-	    (let ((result (!!div 1 (!!add (!!exp (!mul -1 x)) 1))))
-	      (save-for-backward xi result)
-	      result))
+	    (declare (optimize (speed 3)))
+	    (let ((result (data (maybe-copy x))))
+	      (scal! -1.0 result)
+	      (.exp! result)
+	      (.+! 1.0 result)
+	      (.inv! result)
+	      (let ((result (sysconst result)))
+		(save-for-backward xi result)
+		result)))
+  :backward-declaim (declaim (ftype (function (SigmoidTensor waffetensor) list) :backward))
   :backward ((dy) (list (!mul dy
 			      (!mul (self xi)
 				    (!sub 1 (self xi)))))))
@@ -47,11 +56,14 @@ Output: Tensor"
 Input: x where x is waffe supported data type.
 
 Output: Tensor"
+  (declare (optimize (speed 3)))
   (call (SigmoidTensor) (assure-tensor x)))
 
 (defnode TanhTensor nil
   :parameters ((xi T))
+  :forward-declaim (declaim (ftype (function (TanhTensor waffetensor) waffetensor) :forward))
   :forward ((x)
+	    (declare (optimize (speed 3)))
 	    (save-for-backward xi x)
 	    (with-searching-calc-node :tanh x))
   :backward ((dy)
@@ -59,9 +71,11 @@ Output: Tensor"
 
 (defun !tanh (x)
   "Applying tanh to x, return a new sysconst with making nodes."
+  (declare (optimize (speed 3)))
   (call (TanhTensor) (assure-tensor x)))
 
-; Optimizing won't go well
+; No assumption they're work well. (Maybe not.)
+
 (define-with-typevar !gelu u (x &key (approximate t))
   "Applying gelu to x, returning a new sysconst.
 

--- a/source/aref.lisp
+++ b/source/aref.lisp
@@ -8,7 +8,7 @@
   :parameters ((shape shape)
 	       (base-shape T))
   :forward ((x) (setf (self base-shape) (!shape x))
-		(apply #'!faref x (self shape))) ;thread-node??
+		(apply #'!faref x (self shape)))
   :backward ((dy)
 	     (let ((dy-n (!zeros (self base-shape))))
 	       (setf (!areflist dy-n (self shape)) dy)

--- a/source/matrix-operations.lisp
+++ b/source/matrix-operations.lisp
@@ -35,13 +35,20 @@
 	       (yi nil)
 	       (transpose-x? nil)
 	       (transpose-y? nil))
-  :forward ((x y) (save-for-backward xi x)
-		  (save-for-backward yi y)
-		  
-		  (setf (self transpose-x?) (lazy-transpose-p x))
-		  (setf (self transpose-y?) (lazy-transpose-p y))
-		  
-		  (with-searching-calc-node :matmul x y))
+  :forward-declaim (declaim (ftype (function (MatmulTensor waffetensor waffetensor) waffetensor) :forward))
+  :forward ((x y)
+	    (declare (optimize (speed 3) (safety 0)))
+	    (save-for-backward xi x)
+	    (save-for-backward yi y)
+	    
+	    (setf (self transpose-x?) (lazy-transpose-p x))
+	    (setf (self transpose-y?) (lazy-transpose-p y))
+	    (sysconst
+	     (cl-waffe.backends.mgl::matmul-tensor
+	      nil
+	      x
+	      x
+	      y)))
   :backward ((dy)
 	     (list (!matmul dy (if (self transpose-y?)
 				   (progn

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -612,7 +612,6 @@ When backward, @b(Automatic differentiation applies).
 
 (defmacro define-node-extension (name
 				 &key
-				   optimize
 				   backend
 				   (disassemble-forward nil)
 				   forward-declaim
@@ -856,7 +855,7 @@ Example:
 			   (setf (waffetensor-variables x) (flatten (list ,@vars)))
 			   (setf (waffetensor-is-ancestor-param x)
 				 is-ancestor-param)))
-		       x)
+		       (update-tensor-state x (flatten (list ,@vars))))
 		   result)
 		 `(map
 		  'list
@@ -869,7 +868,7 @@ Example:
 	   (T
 	    ,(if (eql object-type :node)
 		 `(unless *no-grad*
-		    (progn
+		    (let ((flat-vars (flatten (list ,@vars))))
 		      (setf
 		       (waffetensor-path-through-node? result)
 		       result-next-state)
@@ -877,14 +876,16 @@ Example:
 		      (setf (waffetensor-state result) (model))
 		      ; Note: variables are flat lists.
 		      ; I hate this overehead of flatten...
-		      (setf (waffetensor-variables result) (flatten (list ,@vars)))
+		      (setf (waffetensor-variables result) flat-vars)
 		      (setf (waffetensor-is-ancestor-param result)
 			    is-ancestor-param)
-		      result)
-		    (progn
+		      result
+		      (setq result (update-tensor-state result flat-vars)))
+		    (let ((flat-vars (flatten (list ,@vars))))
 		      (setf
 		       (waffetensor-path-through-node? result)
-		       result-next-state)))
+		       result-next-state)
+		      (setq result (update-tensor-state result flat-vars))))
 		 `(setf
 		   (waffetensor-path-through-node? result)
 		   result-next-state))
@@ -969,8 +970,6 @@ Example:
 		       backward-declaim
 		       backward
 		       hide-from-tree
-		       optimize
-		       (regard-as-node nil)
 		       (document "An object, defined by cl-waffe")
 		       (object-type :object))
   "Defining cl-waffe's object

--- a/source/model.lisp
+++ b/source/model.lisp
@@ -937,19 +937,23 @@ Example:
 	       declaim-forms))
 	 ,(if disassemble-me
 	      `(defun ,tmp-fname (,self ,@args)
-		 ,@declarations
 		 ,docs
-		 (with-object-macrolet-forms ',self ,args-symbols
-		   ,@body)))
+		 (locally ,@declarations
+		   (with-object-macrolet-forms ',self ,args-symbols
+		     ,(if (find object-type `(:node :optimizer))
+			  `(with-define-function-in-defnode-way ,object-type ,args-symbols
+			     ,@body)
+			  `(with-define-function-in-defmodel-way ,args-symbols
+			     ,@body))))))
 	 (defun ,function-name (,self ,@args)
 	   ,docs
-	   ,@declarations
-	   (with-object-macrolet-forms ',self ',args-symbols
-	     ,(if (find object-type `(:node :optimizer))
-		  `(with-define-function-in-defnode-way ,object-type ,args-symbols
-		     ,@body)
-		  `(with-define-function-in-defmodel-way ,args-symbols
-		     ,@body))))
+	   (locally ,@declarations
+	     (with-object-macrolet-forms ',self ',args-symbols
+	       ,(if (find object-type `(:node :optimizer))
+		    `(with-define-function-in-defnode-way ,object-type ,args-symbols
+		       ,@body)
+		    `(with-define-function-in-defmodel-way ,args-symbols
+		       ,@body)))))
 	 ,(if disassemble-me
 	      `(disassemble #',tmp-fname))
 	 nil))))

--- a/source/operators.lisp
+++ b/source/operators.lisp
@@ -105,6 +105,8 @@ And utils for broadcasting etc...
 (defnode ScalarAdd ()
   :forward-declaim (declaim (ftype (function (ScalarAdd waffetensor waffetensor) waffetensor) :forward))
   :forward ((x y)
+	    (declare (optimize (speed 3))
+		     (type waffetensor x y))
 	    (let ((x (data x))
 		  (y (data y)))
 	      (declare (type single-float x y))

--- a/source/tensor.lisp
+++ b/source/tensor.lisp
@@ -208,6 +208,14 @@ This structure is printable and printed nicely."
   (idx nil :type (or null symbol))
   (is-data-destructed? nil :type boolean))
 
+(declaim (ftype (function (waffetensor) waffetensor) maybe-copy))
+(defun maybe-copy (tensor)
+  "Returns a tensor, if tensor is allowed to destruct. otherwise returns a copy of tensor"
+  (declare (optimize (speed 3)))
+  (if (waffetensor-is-next-destruct? tensor)
+      tensor
+      (sysconst (copy-mat (data tensor)))))
+
 ;(declaim (inline data
 ;		 (setf data)))
 (defun data (tensor)


### PR DESCRIPTION
1. Fix: can't use declare forms in :forward/:backward
2. Accordingly some nodes (e.g: activation functions, matmul) is now optimized